### PR TITLE
fix(profile): update link to developer documentation

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -38,7 +38,7 @@ Hey, this is us 👋 The committers drive this open source project, take respons
 
 Engaged contributors are the heart 💗 of every open source project. For getting started, you may take
 a look at the following links:
-- [Developer documentation](../docs/developer/README.md)
+- [Developer documentation](https://github.com/eclipse-edc/.github/tree/main/docs/developer)
 - [Minimum Viable Dataspace](https://github.com/eclipse-edc/MinimumViableDataspace)
 - [Samples](https://github.com/eclipse-edc/Samples)
 - [YouTube channel](https://www.youtube.com/@eclipsedataspaceconnector9622)


### PR DESCRIPTION
## What this PR changes/adds

Updates link to developer documentation

## Why it does that

Relative links don't seem to work with GitHub profiles

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
