### PR TITLE
feat: add basic workflows from connector repo

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -1,0 +1,54 @@
+name: "Bump version in gradle.properties"
+description: "Increments the patch version of the version found in gradle.properties, appends -SNAPSHOT"
+inputs:
+  target_branch:
+    default: 'main'
+    description: "Branch on which the version bump is to be done."
+    required: false
+  base_version:
+    description: "The current version, which is to be bumped to the next snapshot"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+    - name: read version from gradle.properties
+      shell: bash
+      run: |
+        # Prepare git env
+        git config user.name "eclipse-edc-bot"
+        git config user.email "edc-bot@eclipse.org"
+
+        # checkout target
+        git fetch origin
+        git checkout ${{ inputs.target_branch }}
+
+        # use current version from input
+        baseVersion=${{ inputs.base_version }}
+        existingVersion=$(grep "version" gradle.properties  | awk -F= '{print $2}')
+        
+        # read the major, minor, and patch components, consume -SNAPSHOT
+        IFS=.- read -r RELEASE_VERSION_MAJOR RELEASE_VERSION_MINOR RELEASE_VERSION_PATCH SNAPSHOT<<<"$baseVersion"
+        INC=0
+        # Compute new snapshot version, do not increment snapshot on non-final releases, e.g. -rc1
+        if [ -z $SNAPSHOT ]; then
+          echo "$baseVersion is a final release version, increase patch for next snapshot"
+          INC=1
+        else
+          echo "$baseVersion is not a final release version (contains \"$SNAPSHOT\"), will not increase patch"
+        fi
+
+        # construct the new version
+        newVersion="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+$INC))"-SNAPSHOT
+
+        # replace every occurrence of =$baseVersion with =$newVersion
+        grep -rlz "$existingVersion" . --exclude=\*.{sh,bin} | xargs sed -i "s/$existingVersion/$newVersion/g"
+
+        echo "Bumped the version from $baseVersion to $newVersion"
+
+        # Commit and push to the desired branch, defaults to 'main'
+        git add .
+        git commit --message "Bump version from $baseVersion to $newVersion [skip ci]"
+
+        git push origin ${{ inputs.target_branch }}

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,0 +1,21 @@
+name: "Run tests"
+description: "Run tests and archive test results for subsequent publication"
+inputs:
+  command:
+    required: true
+    description: "The shell command to run tests"
+runs:
+  using: "composite"
+  steps:
+    - name: Run Tests
+      shell: bash
+      run: ${{ inputs.command }}
+
+    - name: Upload Test Results
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: Test Results ${{ github.job }}
+        path: |
+          **/test-results/**/*.xml
+          **/build/reports/jacoco/test/jacocoTestReport.xml

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,0 +1,9 @@
+name: "Setup Gradle"
+description: "Setup Gradle"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,21 @@
+# This file determines how the auto-generated Release Notes in GitHub releases are structured.
+
+changelog:
+  exclude:
+    labels:
+      - no-changelog
+    authors:
+      - dependabot[bot]
+  categories:
+    - title: Bugfixes
+      labels:
+        - bug
+    - title: New Features & Improvements
+      labels:
+        - "*"
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Documentation
+      labels:
+        - documentation

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,17 @@
+name: Add to Project
+
+on:
+  issues:
+    types: [ opened ]
+  pull_request_target:
+    types: [ opened ]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue
+        uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/eclipse-edc/projects/3
+          github-token: ${{ secrets.ORGANIZATION_PROJECT }}

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -1,0 +1,23 @@
+---
+name: "Bump version (manually)"
+
+on:
+  # can be called manually from GH webpage
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        default: 'main'
+        description: "Branch on which the version bump is to be done."
+        required: false
+
+
+jobs:
+  Bump-Version:
+    name: 'Update snapshot version'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/bump-version
+        name: Bump version
+        with:
+          target_branch: ${{ inputs.target_branch }}

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -1,0 +1,88 @@
+name: Close Inactive Issues
+on:
+  schedule:
+    - cron: "30 1 * * *" # once a day (1:30 UTC)
+  workflow_dispatch: # allow manual trigger
+
+jobs:
+  close-issues-in-triage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v8
+        with:
+          operations-per-run: 1000
+          days-before-issue-stale: 28
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 28 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          close-issue-reason: 'not_planned'
+          days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
+          days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
+          remove-issue-stale-when-updated: true
+          exempt-all-issue-milestones: false # issues with assigned milestones will be ignored
+          only-labels: 'triage'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  close-issues-with-assignee:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v8
+        with:
+          operations-per-run: 1000
+          days-before-issue-stale: 28
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 28 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          close-issue-reason: 'not_planned'
+          days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
+          days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
+          remove-issue-stale-when-updated: true
+          exempt-all-issue-milestones: true # issues with assigned milestones will be ignored
+          exempt-issue-labels: bug # ignore issues labelled as bug
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  close-issues-without-assignee:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v8
+        with:
+          operations-per-run: 1000
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 14 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          close-issue-reason: 'not_planned'
+          days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
+          days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
+          remove-issue-stale-when-updated: true
+          exempt-all-issue-milestones: true # issues with assigned milestones will be ignored
+          exempt-all-issue-assignees: true # issues with assignees will be ignored
+          exempt-issue-labels: bug # ignore issues labelled as bug
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  close-inactive-pull-requests:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v8
+        with:
+          operations-per-run: 1000
+          days-before-issue-stale: -1 # ignore issues (overwrite default days-before-stale)
+          days-before-issue-close: -1 # ignore issues (overwrite default days-before-close)
+          stale-pr-label: "stale"
+          stale-pr-message: "This pull request is stale because it has been open for 7 days with no activity."
+          close-pr-message: "This pull request was closed because it has been inactive for 7 days since being marked as stale."
+          days-before-pr-stale: 7
+          days-before-pr-close: 7
+          remove-pr-stale-when-updated: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/discord-webhook.yml
+++ b/.github/workflows/discord-webhook.yml
@@ -1,0 +1,51 @@
+name: 'Discord Webhook'
+on:
+  issues:
+    types: [ opened ]
+  pull_request_target:
+    types: [ opened, reopened ]
+  discussion:
+    types: [ created ]
+
+jobs:
+  message:
+    runs-on: ubuntu-latest
+    steps:
+      - name: New Discussion
+        uses: tsickert/discord-webhook@v5.3.0
+        if: ${{ (github.event_name == 'discussion') }}
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          avatar-url: https://avatars.githubusercontent.com/u/9919?s=200&v=4
+          embed-author-name: ${{ github.event.sender.login }}
+          embed-author-url: ${{ github.event.sender.html_url }}
+          embed-author-icon-url: ${{ github.event.sender.avatar_url }}
+          embed-title: ${{ github.event.discussion.title }}
+          embed-url: ${{ github.event.discussion.html_url }}
+          embed-description: A **discussion** has been created in ${{ github.repository }}.
+
+      - name: New Issue
+        uses: tsickert/discord-webhook@v5.3.0
+        if: ${{ (github.event_name == 'issues') }}
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          avatar-url: https://avatars.githubusercontent.com/u/9919?s=200&v=4
+          embed-author-name: ${{ github.event.sender.login }}
+          embed-author-url: ${{ github.event.sender.html_url }}
+          embed-author-icon-url: ${{ github.event.sender.avatar_url }}
+          embed-title: ${{ github.event.issue.title }}
+          embed-url: ${{ github.event.issue.html_url }}
+          embed-description: An **issue** has been opened in ${{ github.repository }}.
+
+      - name: New Pull Request
+        uses: tsickert/discord-webhook@v5.3.0
+        if: ${{ (github.event_name == 'pull_request_target') }}
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          avatar-url: https://avatars.githubusercontent.com/u/9919?s=200&v=4
+          embed-author-name: ${{ github.event.sender.login }}
+          embed-author-url: ${{ github.event.sender.html_url }}
+          embed-author-icon-url: ${{ github.event.sender.avatar_url }}
+          embed-title: ${{ github.event.pull_request.title }}
+          embed-url: ${{ github.event.pull_request.html_url }}
+          embed-description: A **pull request** has been opened in ${{ github.repository }}.

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -1,0 +1,21 @@
+name: First Interaction
+
+on:
+  issues:
+    types: [ opened ]
+  pull_request_target:
+    types: [ opened ]
+
+jobs:
+  add-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: 'Thanks for your contribution :fire: We will take a look asap :rocket:'
+          pr-message: >-
+            We are always happy to welcome new contributors :heart: To make things easier for everyone, please
+            make sure to follow our [contribution guidelines](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md),
+            check if you have already signed the [ECA](http://www.eclipse.org/legal/ecafaq.php), and
+            relate this pull request to an existing issue or discussion.


### PR DESCRIPTION
## What this PR changes/adds

Adds actions and workflows as-is:
- `./actions`
- `add-to-project`
- `bump-version`
- `close-inactive-issues`
- `discord-webhook`
- `first-interaction`
- `release`

Added dependency categorie to release notes.

## Why it does that

Enhance maintenance

## Further notes

Workflows need to be removed from other repos step-by-step.

`trigger_snapshot` and `release-edc` will follow in another PR

## Linked Issue(s)

Relates eclipse-edc/Connector#3033

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
