### PR TITLE
feat(ci): add DEPENDENCIES check workflow

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -34,24 +34,37 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-build
+      - name: Check if DEPENDENCIES file exists
+        id: check-if-exists
+        run: |
+          [ ! -f DEPENDENCIES ] && echo "DEPENDENCIES_EXISTS=true" >> $GITHUB_OUTPUT
+          exit 0
+
       - name: Download latest Eclipse Dash
+
         run: |
           curl -L https://repo.eclipse.org/service/local/artifact/maven/redirect\?r\=dash-licenses\&g\=org.eclipse.dash\&a\=org.eclipse.dash.licenses\&v\=LATEST --output dash.jar
       - name: Regenerate DEPENDENCIES
         run: |
-          # dash returns a nonzero exit code if there are libs that need review. the "|| true" avoids that
-          ./gradlew allDependencies | grep -Poh "(?<=\s)[\w.-]+:[\w.-]+:[^:\s\[\]]+" | sort | uniq | java -jar dash.jar - -summary DEPENDENCIES-gen || true
-
-          # log warning if restricted deps are found
-          grep -E 'restricted' DEPENDENCIES | if test $(wc -l) -gt 0; then 
-            echo "::warning file=DEPENDENCIES,title=Restricted Dependencies found::Some dependencies are marked 'restricted' - please review them" 
-          fi
-
-          # log error and fail job if rejected deps are found
-          grep -E 'rejected' DEPENDENCIES | if test $(wc -l) -gt 0; then
-            echo "::error file=DEPENDENCIES,title=Rejected Dependencies found::Some dependencies are marked 'rejected', they cannot be used"
-            exit 1
+          if [ -f DEPENDENCIES ]; then
+            # dash returns a nonzero exit code if there are libs that need review. the "|| true" avoids that
+            ./gradlew allDependencies | grep -Poh "(?<=\s)[\w.-]+:[\w.-]+:[^:\s\[\]]+" | sort | uniq | java -jar dash.jar - -summary DEPENDENCIES-gen || true
+  
+            # log warning if restricted deps are found
+            grep -E 'restricted' DEPENDENCIES | if test $(wc -l) -gt 0; then 
+              echo "::warning file=DEPENDENCIES,title=Restricted Dependencies found::Some dependencies are marked 'restricted' - please review them" 
+            fi
+  
+            # log error and fail job if rejected deps are found
+            grep -E 'rejected' DEPENDENCIES | if test $(wc -l) -gt 0; then
+              echo "::error file=DEPENDENCIES,title=Rejected Dependencies found::Some dependencies are marked 'rejected', they cannot be used"
+              exit 1
+            fi
+          else
+            echo "::warning file=DEPENDENCIES,title=DEPENDENCIES file missing::The DEPENDENCIES file was missing, the checks did not run."
           fi
       - name: Check for differences
         run: |
-          diff DEPENDENCIES DEPENDENCIES-gen
+          if [ -f DEPENDENCIES ]; then
+            diff DEPENDENCIES DEPENDENCIES-gen
+          fi

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,57 @@
+name: 'Dependency Review'
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  Check-Allowed-Licenses:
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v3
+        with:
+          fail-on-severity: critical
+          # Representation of this list: https://www.eclipse.org/legal/licenses.php#
+          # Expressed with the help of the following IDs: https://spdx.org/licenses/
+          allow-licenses: >-
+            Adobe-Glyph, Apache-1.0, Apache-1.1, Apache-2.0, Artistic-2.0, BSD-2-Clause, BSD-3-Clause,
+            BSD-4-Clause, 0BSD, BSL-1.0, CDDL-1.0, CDDL-1.1, CPL-1.0, CC-BY-3.0, CC-BY-4.0, CC-BY-2.5,
+            CC-BY-SA-3.0, CC-BY-SA-4.0, CC0-1.0, EPL-1.0, EPL-2.0, FTL, GFDL-1.3-only, IPL-1.0, ISC,
+            MIT, MIT-0, MPL-1.1, MPL-2.0, NTP, OpenSSL, PHP-3.01, PostgreSQL, OFL-1.1, Unlicense,
+            Unicode-DFS-2015, Unicode-DFS-2016, Unicode-TOU, UPL-1.0, W3C-20150513, W3C-19980720, W3C,
+            WTFPL, X11, Zlib, ZPL-2.1
+
+  Dash-Dependency-Check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-build
+      - name: Download latest Eclipse Dash
+        run: |
+          curl -L https://repo.eclipse.org/service/local/artifact/maven/redirect\?r\=dash-licenses\&g\=org.eclipse.dash\&a\=org.eclipse.dash.licenses\&v\=LATEST --output dash.jar
+      - name: Regenerate DEPENDENCIES
+        run: |
+          # dash returns a nonzero exit code if there are libs that need review. the "|| true" avoids that
+          ./gradlew allDependencies | grep -Poh "(?<=\s)[\w.-]+:[\w.-]+:[^:\s\[\]]+" | sort | uniq | java -jar dash.jar - -summary DEPENDENCIES-gen || true
+
+          # log warning if restricted deps are found
+          grep -E 'restricted' DEPENDENCIES | if test $(wc -l) -gt 0; then 
+            echo "::warning file=DEPENDENCIES,title=Restricted Dependencies found::Some dependencies are marked 'restricted' - please review them" 
+          fi
+
+          # log error and fail job if rejected deps are found
+          grep -E 'rejected' DEPENDENCIES | if test $(wc -l) -gt 0; then
+            echo "::error file=DEPENDENCIES,title=Rejected Dependencies found::Some dependencies are marked 'rejected', they cannot be used"
+            exit 1
+          fi
+      - name: Check for differences
+        run: |
+          diff DEPENDENCIES DEPENDENCIES-gen

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -34,14 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-build
-      - name: Check if DEPENDENCIES file exists
-        id: check-if-exists
-        run: |
-          [ ! -f DEPENDENCIES ] && echo "DEPENDENCIES_EXISTS=true" >> $GITHUB_OUTPUT
-          exit 0
-
       - name: Download latest Eclipse Dash
-
         run: |
           curl -L https://repo.eclipse.org/service/local/artifact/maven/redirect\?r\=dash-licenses\&g\=org.eclipse.dash\&a\=org.eclipse.dash.licenses\&v\=LATEST --output dash.jar
       - name: Regenerate DEPENDENCIES


### PR DESCRIPTION
## What this PR changes/adds

Adds a workflow, that:
- checks for allowed licenses in all dependencies
- verifies that the DEPENDENCIES file is still up to date and does not contain any `rejected` libs

## Why it does that

Compliance with Eclipse

## Further notes

- the same workflow file, and an initial DEPENDENCIES file will be added to all existing repos.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
