### PR TITLE
feat: add reusable workflows

### DIFF
--- a/.github/workflows/discord-webhook.yml
+++ b/.github/workflows/discord-webhook.yml
@@ -1,11 +1,15 @@
 name: 'Discord Webhook'
+
 on:
-  issues:
-    types: [ opened ]
-  pull_request_target:
-    types: [ opened, reopened ]
-  discussion:
-    types: [ created ]
+  workflow_call:
+    inputs:
+      event-name:
+        required: true
+      event:
+        required: true
+    secrets:
+      envDiscord:
+        required: true
 
 jobs:
   message:
@@ -13,39 +17,39 @@ jobs:
     steps:
       - name: New Discussion
         uses: tsickert/discord-webhook@v5.3.0
-        if: ${{ (github.event_name == 'discussion') }}
+        if: ${{ (input.event-name == 'discussion') }}
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          webhook-url: ${{ secrets.envDiscord }}
           avatar-url: https://avatars.githubusercontent.com/u/9919?s=200&v=4
-          embed-author-name: ${{ github.event.sender.login }}
-          embed-author-url: ${{ github.event.sender.html_url }}
-          embed-author-icon-url: ${{ github.event.sender.avatar_url }}
-          embed-title: ${{ github.event.discussion.title }}
-          embed-url: ${{ github.event.discussion.html_url }}
-          embed-description: A **discussion** has been created in ${{ github.repository }}.
+          embed-author-name: ${{ input.event.sender.login }}
+          embed-author-url: ${{ input.event.sender.html_url }}
+          embed-author-icon-url: ${{ input.event.sender.avatar_url }}
+          embed-title: ${{ input.event.discussion.title }}
+          embed-url: ${{ input.event.discussion.html_url }}
+          embed-description: A **discussion** has been created in ${{ input.repository }}.
 
       - name: New Issue
         uses: tsickert/discord-webhook@v5.3.0
-        if: ${{ (github.event_name == 'issues') }}
+        if: ${{ (input.event-name == 'issues') }}
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          webhook-url: ${{ secrets.envDiscord }}
           avatar-url: https://avatars.githubusercontent.com/u/9919?s=200&v=4
-          embed-author-name: ${{ github.event.sender.login }}
-          embed-author-url: ${{ github.event.sender.html_url }}
-          embed-author-icon-url: ${{ github.event.sender.avatar_url }}
-          embed-title: ${{ github.event.issue.title }}
-          embed-url: ${{ github.event.issue.html_url }}
-          embed-description: An **issue** has been opened in ${{ github.repository }}.
+          embed-author-name: ${{ input.event.sender.login }}
+          embed-author-url: ${{ input.event.sender.html_url }}
+          embed-author-icon-url: ${{ input.event.sender.avatar_url }}
+          embed-title: ${{ input.event.issue.title }}
+          embed-url: ${{ input.event.issue.html_url }}
+          embed-description: An **issue** has been opened in ${{ input.repository }}.
 
       - name: New Pull Request
         uses: tsickert/discord-webhook@v5.3.0
-        if: ${{ (github.event_name == 'pull_request_target') }}
+        if: ${{ (input.event-name == 'pull_request_target') }}
         with:
-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          webhook-url: ${{ secrets.envDiscord }}
           avatar-url: https://avatars.githubusercontent.com/u/9919?s=200&v=4
-          embed-author-name: ${{ github.event.sender.login }}
-          embed-author-url: ${{ github.event.sender.html_url }}
-          embed-author-icon-url: ${{ github.event.sender.avatar_url }}
-          embed-title: ${{ github.event.pull_request.title }}
-          embed-url: ${{ github.event.pull_request.html_url }}
-          embed-description: A **pull request** has been opened in ${{ github.repository }}.
+          embed-author-name: ${{ input.event.sender.login }}
+          embed-author-url: ${{ input.event.sender.html_url }}
+          embed-author-icon-url: ${{ input.event.sender.avatar_url }}
+          embed-title: ${{ input.event.pull_request.title }}
+          embed-url: ${{ input.event.pull_request.html_url }}
+          embed-description: A **pull request** has been opened in ${{ input.repository }}.

--- a/.github/workflows/discord-webhook.yml
+++ b/.github/workflows/discord-webhook.yml
@@ -7,6 +7,8 @@ on:
         required: true
       event:
         required: true
+      repository:
+        required: true
     secrets:
       envDiscord:
         required: true

--- a/.github/workflows/first-interaction.yml
+++ b/.github/workflows/first-interaction.yml
@@ -1,10 +1,10 @@
 name: First Interaction
 
 on:
-  issues:
-    types: [ opened ]
-  pull_request_target:
-    types: [ opened ]
+  workflow_call:
+    secrets:
+      envGH:
+        required: true
 
 jobs:
   add-comment:
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/first-interaction@v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.envGH }}
           issue-message: 'Thanks for your contribution :fire: We will take a look asap :rocket:'
           pr-message: >-
             We are always happy to welcome new contributors :heart: To make things easier for everyone, please

--- a/.github/workflows/scan-pull-request.yml
+++ b/.github/workflows/scan-pull-request.yml
@@ -1,13 +1,10 @@
 name: Scan Pull Request
 
 on:
-  pull_request:
-    branches: [ main ]
-    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_call:
+    secrets:
+      envGH:
+        required: true
 
 jobs:
   check-pull-request-title:
@@ -39,4 +36,4 @@ jobs:
       - uses: agilepathway/label-checker@v1.4.30
         with:
           any_of: api,bug,build,dependencies,documentation,enhancement,no-changelog,refactoring
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          repo_token: ${{ secrets.envGH }}

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,8 +1,10 @@
 name: Close Inactive Issues
+
 on:
-  schedule:
-    - cron: "30 1 * * *" # once a day (1:30 UTC)
-  workflow_dispatch: # allow manual trigger
+  workflow_call:
+    secrets:
+      envGH:
+        required: true
 
 jobs:
   close-issues-in-triage:
@@ -24,7 +26,7 @@ jobs:
           remove-issue-stale-when-updated: true
           exempt-all-issue-milestones: false # issues with assigned milestones will be ignored
           only-labels: 'triage'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.envGH }}
 
   close-issues-with-assignee:
     runs-on: ubuntu-latest
@@ -45,7 +47,7 @@ jobs:
           remove-issue-stale-when-updated: true
           exempt-all-issue-milestones: true # issues with assigned milestones will be ignored
           exempt-issue-labels: bug # ignore issues labelled as bug
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.envGH }}
 
   close-issues-without-assignee:
     runs-on: ubuntu-latest
@@ -67,7 +69,7 @@ jobs:
           exempt-all-issue-milestones: true # issues with assigned milestones will be ignored
           exempt-all-issue-assignees: true # issues with assignees will be ignored
           exempt-issue-labels: bug # ignore issues labelled as bug
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.envGH }}
 
   close-inactive-pull-requests:
     runs-on: ubuntu-latest
@@ -85,4 +87,4 @@ jobs:
           days-before-pr-stale: 7
           days-before-pr-close: 7
           remove-pr-stale-when-updated: true
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.envGH }}

--- a/contributing/pr_etiquette.md
+++ b/contributing/pr_etiquette.md
@@ -34,7 +34,7 @@ Submitting pull requests in EDC should be done while adhering to a couple of sim
   - The title must follow the format as `<type>(<optional scope>): <description>`.
     `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test` are allowed for the `<type>`.
   - The length must be kept under 80 characters.
-  - See [check-pull-request-title job of GitHub workflow](../.github/workflows/scan-pull-request.yaml) for checking details.
+  - See [check-pull-request-title job of GitHub workflow](../.github/workflows/scan-pull-request.yml) for checking details.
 
 ## As a reviewer
 


### PR DESCRIPTION
## What this PR changes/adds

Following the GitHub documentation, we can use [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) to enhance the maintenance of workflows. The workflows will be placed in this repo and referenced from workflow files in the other repos. This way, workflow changes will automatically apply to all repos. 

## Why it does that

Enhance maintenance

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
