### PR TITLE
fix: print dependencies file on failure

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -40,8 +40,8 @@ jobs:
           ./gradlew allDependencies | grep -Poh "(?<=\s)[\w.-]+:[\w.-]+:[^:\s\[\]]+" | sort | uniq | java -jar dash.jar - -summary DEPENDENCIES-gen || true
 
           # log warning if restricted deps are found
-          grep -E 'restricted' DEPENDENCIES | if test $(wc -l) -gt 0; then 
-            echo "::warning file=DEPENDENCIES,title=Restricted Dependencies found::Some dependencies are marked 'restricted' - please review them" 
+          grep -E 'restricted' DEPENDENCIES | if test $(wc -l) -gt 0; then
+            echo "::warning file=DEPENDENCIES,title=Restricted Dependencies found::Some dependencies are marked 'restricted' - please review them"
           fi
 
           # log error and fail job if rejected deps are found
@@ -54,11 +54,11 @@ jobs:
           if diff DEPENDENCIES DEPENDENCIES-gen ; then
             echo "DEPENDENCIES up-do-date"
           else
-            diff DEPENDENCIES DEPENDENCIES-gen
+            diff DEPENDENCIES DEPENDENCIES-gen || true
             echo "------------------------------------------------------------"
-            echo "Please copy the following content back to DEPENDENCIES" 
+            echo "=== Please copy the following content back to DEPENDENCIES ==="
             cat DEPENDENCIES-gen
-            echo "end of content"
+            echo "=== end of content ==="
             echo "::error file=DEPENDENCIES,title=Dependencies outdated::The DEPENDENCIES file was outdated and must be regenerated. Check the output of this job for more information"
             exit 1
           fi


### PR DESCRIPTION
## What this PR changes/adds

Ignore `diff` exit status

## Why it does that

print the correct DEPENDENCIES file 

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
