### PR TITLE
feat(build): publish to OSSRH Snapshots and MavenCentral from GHA

### DIFF
--- a/.github/actions/import-gpg-key/action.yml
+++ b/.github/actions/import-gpg-key/action.yml
@@ -1,0 +1,25 @@
+name: "Import GPG Key"
+description: "Imports a GPG key given in the input"
+inputs:
+  gpg-private-key:
+    required: true
+    description: "The GPG Private Key in plain text. Can be a sub-key."
+runs:
+  using: "composite"
+  steps:
+    # this is necessary because it creates gpg.conf, etc.
+    - name: List Keys
+      shell: bash
+      run: |
+        gpg -K --keyid-format=long
+
+    - name: Import GPG Private Key
+      shell: bash
+      run: |
+        echo "use-agent" >> ~/.gnupg/gpg.conf
+        echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+        echo -e "${{ inputs.gpg-private-key }}" | gpg --import --batch
+        for fpr in $(gpg --list-keys --with-colons | awk -F: '/fpr:/ {print $10}' | sort -u);
+        do
+          echo -e "5\\ny\\n" |  gpg --batch --command-fd 0 --expert --edit-key $fpr trust;
+        done

--- a/.github/workflows/_trigger-snapshot.yml
+++ b/.github/workflows/_trigger-snapshot.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   trigger-workflow:
-    uses: eclipse-edc/.github/.github/workflows/trigger-snapshot.yml@main
+    uses: eclipse-edc/.github/.github/workflows/publish-snapshot.yml@main
     with:
       github_repository: ${{ github.repository }}
     secrets:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -23,7 +23,7 @@ jobs:
           [ ! -z "${{ secrets.ORG_OSSRH_USERNAME }}" ] && echo "HAS_OSSRH=true" >> $GITHUB_OUTPUT
           exit 0
 
-  Trigger-Snapshot:
+  Publish-Snapshot:
     name: "Publish artefacts to OSSRH Snapshots / MavenCentral"
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/trigger-snapshot.yml
+++ b/.github/workflows/trigger-snapshot.yml
@@ -1,36 +1,59 @@
-name: "Create Snapshot Build"
+name: "Publish Snapshot Build"
 
 on:
+  workflow_dispatch:
   workflow_call:
-    inputs:
-      github_repository:
-        required: true
-        type: string
-    secrets:
-      jenkins_user:
-        required: true
-      jenkins_token:
-        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  Trigger-Snapshot:
+  secrets-presence:
+    name: "Check for required credentials"
     runs-on: ubuntu-latest
-    # forks cannot trigger Jenkins
-    if: ${{ startsWith( inputs.github_repository, 'eclipse-edc') }}
+    outputs:
+      HAS_OSSRH: ${{ steps.secret-presence.outputs.HAS_OSSRH }}
     steps:
-      # Trigger EF Jenkins. This job waits for Jenkins to complete the publishing, which may take a long time, because every
-      # module is signed individually, and parallelism is not available. Hence, the increased timeout of 3600 seconds.
-      # There is no way to cancel the process on Jenkins from withing GitHub.
-      - name: Call Jenkins API to trigger build
-        uses: toptal/jenkins-job-trigger-action@master
+      - name: Check whether secrets exist
+        id: secret-presence
+        run: |
+          [ ! -z "${{ secrets.ORG_GPG_PASSPHRASE }}" ] &&
+          [ ! -z "${{ secrets.ORG_GPG_PRIVATE_KEY }}" ] &&
+          [ ! -z "${{ secrets.ORG_OSSRH_USERNAME }}" ] && echo "HAS_OSSRH=true" >> $GITHUB_OUTPUT
+          exit 0
+
+  Trigger-Snapshot:
+    name: "Publish artefacts to OSSRH Snapshots / MavenCentral"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    needs: [ secrets-presence ]
+
+    if: |
+      needs.secrets-presence.outputs.HAS_OSSRH
+    steps:
+      # Set-Up
+      - uses: actions/checkout@v3.5.2
+
+      # Import GPG Key
+      - uses: ./.github/actions/import-gpg-key
+        name: "Import GPG Key"
         with:
-          jenkins_url: "https://ci.eclipse.org/edc/"
-          jenkins_user: ${{ secrets.jenkins_user }}
-          jenkins_token: ${{ secrets.jenkins_token }}
-          # empty params are needed, otherwise the job will fail.
-          job_params: |
-            {
-              "REPO": join('https://github.com/', ${{ inputs.github_repository }})
-            }
-          job_name: "Publish-Component"
-          job_timeout: "3600" # Default 30 sec. (optional)
+          gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+
+      - uses: ./.github/actions/setup-build
+      - name: "Publish snapshot version"
+        env:
+          OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
+          OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
+        run: |-
+          VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
+          if [[ $VERSION != *-SNAPSHOT ]]
+          then
+            echo "::warning file=gradle.properties::$VERSION is not a snapshot version - will not publish!"
+            exit 0
+          fi
+          echo "Publishing Version $VERSION to Sonatype"
+          ./gradlew publishToSonatype --no-parallel -Pversion=$VERSION -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}"


### PR DESCRIPTION
## What this PR changes/adds

Adds a base workflow (and action) so that EDC projects can directly publish to Sonatype Snapshots from GHA.

## Why it does that

Avoid going to Jenkins

## Further notes

- Once this is merged, we can update all the `trigger-snapshot.yaml` files in all the components, so that they actually invoke this workflow here.
- successful run: https://github.com/eclipse-edc/Runtime-Metamodel/actions/runs/6170964283/job/16748285538

## Linked Issue(s)

Closes #https://github.com/eclipse-edc/.github/issues/71

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
