### PR TITLE
fix: add absolute reference to .github workflows & actions

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/bump-version
+      - uses: eclipse-edc/.github/.github/actions/bump-version@main
         name: Bump version
         with:
           target_branch: ${{ inputs.target_branch }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-build
+      - uses: eclipse-edc/.github/.github/actions/setup-build@main
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/release-component.yml
+++ b/.github/workflows/release-component.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/bump-version
+      - uses: eclipse-edc/.github/.github/actions/bump-version@main
         with:
           target_branch: "main"
           base_version: ${{ needs.Prepare-Release.outputs.component-version }}


### PR DESCRIPTION
## What this PR changes/adds

Adds absolute reference to .github workflows & actions

## Why it does that

Relative references are failing (see https://github.com/eclipse-edc/Template-Basic/pull/2) when run in an external repo. Seems like this has been missed in #63.

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
