### PR TITLE
build: fix version extraction

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -45,7 +45,7 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
           OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
         run: |-
-          VERSION=$(./gradlew properties -q | grep "version:" | awk '{print $2}')
+          VERSION=$(./gradlew properties -q | grep "version: " | awk '{print $2}')
           if [[ $VERSION != *-SNAPSHOT ]]
           then
             echo "::warning file=gradle.properties::$VERSION is not a snapshot version - will not publish!"


### PR DESCRIPTION
## What this PR changes/adds

Fix the `grep` expression to extract the project version, from `version:` to `version: ` with a trailing colon, this because now in `Connector` we have modules that contains the `version:` string in path.

failing workflow example: https://github.com/eclipse-edc/Connector/actions/runs/8017082606/job/21900245378

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
