### PR TITLE
build: reusable workflow for build and upload openapi spec ui to github pages

### DIFF
--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -3,14 +3,16 @@ name: publish swagger ui
 on:
   workflow_call:
     inputs:
-      api_groups:
-        required: true
-        description: "API group names"
+      version:
+        required: false
+        description: "version override"
         type: string
 
 jobs:
   generate-openapi-spec:
     runs-on: ubuntu-latest
+    outputs:
+      api_groups: ${{ steps.outputStep.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
@@ -20,13 +22,17 @@ jobs:
         with:
           name: openapi-spec
           path: resources/openapi/yaml
+      - name: get api groups and create matrix for next job
+        id: outputStep
+        run: |
+          API_GROUPS_ARRAY=$(ls -l resources/openapi/yaml | grep '^d' | awk '{print $9}' | sed ':a; N; $!ba; s/\n/","/g' | sed 's/.*/["&"]/')
+          echo "matrix={\"apiGroup\": ${API_GROUPS_ARRAY}}" >> $GITHUB_OUTPUT
 
   generate-swagger-ui:
     needs: generate-openapi-spec
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        apiGroup: ${{ fromJSON(inputs.api_groups) }}
+      matrix: ${{ fromJson(needs.generate-openapi-spec.outputs.api_groups) }}
     env:
       rootDir: resources/openapi/yaml/${{ matrix.apiGroup }}
     steps:
@@ -35,6 +41,11 @@ jobs:
         with:
           name: openapi-spec
           path: resources/openapi/yaml
+
+      - name: Override version if input is set
+        if: "${{ github.event.inputs.version != '' }}"
+        run: sed -i "s/version=.*/version=${{ github.event.inputs.version }}/g" gradle.properties
+
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
 
       # merge together all api groups
@@ -62,6 +73,7 @@ jobs:
         with:
           name: ${{ matrix.apiGroup }}
           path: swagger-ui
+
 
   deploy-swagger-ui:
     needs: generate-swagger-ui

--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -1,0 +1,79 @@
+name: publish swagger ui
+
+on:
+  workflow_call:
+    inputs:
+      api_groups:
+        required: true
+        description: "API group names"
+        type: string
+
+jobs:
+  generate-openapi-spec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: eclipse-edc/.github/.github/actions/setup-build@main
+      - name: Generate API Specs
+        run: ./gradlew resolve
+      - uses: actions/upload-artifact@v4
+        with:
+          name: openapi-spec
+          path: resources/openapi/yaml
+
+  generate-swagger-ui:
+    needs: generate-openapi-spec
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        apiGroup: ${{ fromJSON(inputs.api_groups) }}
+    env:
+      rootDir: resources/openapi/yaml/${{ matrix.apiGroup }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: openapi-spec
+          path: resources/openapi/yaml
+      - uses: eclipse-edc/.github/.github/actions/setup-build@main
+
+      # merge together all api groups
+      - name: Generate API Specs
+        run: |
+          ./gradlew -PapiTitle="${{ matrix.apiGroup }}" -PapiDescription="REST API documentation for the ${{ matrix.apiGroup }}" :mergeApiSpec --input=${{ env.rootDir }} --output=${{ matrix.apiGroup }}.yaml
+
+      - name: extract version
+        run: echo "VERSION=$(grep version= gradle.properties | cut -c 9-)" >> $GITHUB_ENV
+
+      - name: Generate Swagger UI current version
+        uses: Legion2/swagger-ui-action@v1
+        with:
+          output: swagger-ui/${{ env.VERSION }}
+          spec-file: ${{ matrix.apiGroup }}.yaml
+
+      - name: Generate Swagger UI stable version
+        uses: Legion2/swagger-ui-action@v1
+        if: ${{ !endsWith( env.VERSION, '-SNAPSHOT') }}
+        with:
+          output: swagger-ui
+          spec-file: ${{ matrix.apiGroup }}.yaml
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.apiGroup }}
+          path: swagger-ui
+
+  deploy-swagger-ui:
+    needs: generate-swagger-ui
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: openapi
+          pattern: "*-api"
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .
+          keep_files: true


### PR DESCRIPTION
## What this PR changes/adds

Add a reusable workflow that, given the list of `api_groups` in input, generates openapi, generates swagger ui sites and deploy them on the repository github pages with the following url:

`https://<org>.github.io/<repo-name>/openapi/<api-group>/<version>`

if the version is not snapshot (e.g. for stable releases, the ui will be also published at:

`https://<org>.github.io/<repo-name>/openapi/<api-group>`

## Why it does that

openapi spec availability

## Further notes

- the workflow is divided in 3 jobs:
  1. generate openapi spec by calling `./gradlew resolve` and upload the produced artifacts
  2. download the specs and merge them for every `api-group`, generate "version" ui and, in the case of a non snapshot version, generate also one without version (a `cp` would have been enough but also generating them takes no time). Upload the UIs
  3.  download all the UIs, deploy them to GH pages, keeping the existing files (to avoid deleting old versions)

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
