### PR TITLE
build: publish autodoc output on github pages workflow

### DIFF
--- a/.github/workflows/publish-autodoc.yml
+++ b/.github/workflows/publish-autodoc.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Generate docs
         run: ./gradlew autodoc
       - name: Merge manifests
-        run: ./gradlew mergeManifest
+        run: ./gradlew mergeManifests
       - name: Render markdown
         run: |
           ./gradlew doc2md

--- a/.github/workflows/publish-autodoc.yml
+++ b/.github/workflows/publish-autodoc.yml
@@ -1,0 +1,52 @@
+name: publish autodoc
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: false
+        description: "version override"
+        type: string
+
+jobs:
+  generate-and-deploy-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: eclipse-edc/.github/.github/actions/setup-build@main
+
+      - name: Override version if input is set
+        if: "${{ github.event.inputs.version != '' }}"
+        run: sed -i "s/version=.*/version=${{ github.event.inputs.version }}/g" gradle.properties
+
+      - name: Generate docs
+        run: ./gradlew autodoc
+      - name: Merge manifests
+        run: ./gradlew mergeManifest
+      - name: Render markdown
+        run: |
+          ./gradlew doc2md
+          cp build/*.md build/manifest.md
+
+      - name: extract version
+        run: echo "VERSION=$(grep version= gradle.properties | cut -c 9-)" >> $GITHUB_ENV
+
+      - name: Prepare deploy folder
+        run: |
+          mkdir -p deploy/autodoc/${{ env.VERSION }}
+
+      - name: Render html
+        uses: docker://pandoc/core:latest
+        with:
+          args: --standalone --from gfm --to html --output deploy/autodoc/${{ env.VERSION }}/index.html build/manifest.md
+
+      - name: Render html for stable version
+        if: ${{ !endsWith( env.VERSION, '-SNAPSHOT') }}
+        run: cp deploy/autodoc/${{ env.VERSION }}/index.html deploy/autodoc/index.html
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: deploy
+          keep_files: true


### PR DESCRIPTION
## What this PR changes/adds

Reusable workflow to publish autodoc output to github pages

## Why it does that

documentation

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
