### PR TITLE
build: use doc2html for publishing autodoc

### DIFF
--- a/.github/workflows/publish-autodoc.yml
+++ b/.github/workflows/publish-autodoc.yml
@@ -24,9 +24,7 @@ jobs:
       - name: Merge manifests
         run: ./gradlew mergeManifests
       - name: Render markdown
-        run: |
-          ./gradlew doc2md
-          cp build/*.md build/manifest.md
+        run: ./gradlew doc2html
 
       - name: extract version
         run: echo "VERSION=$(grep version= gradle.properties | cut -c 9-)" >> $GITHUB_ENV
@@ -34,11 +32,7 @@ jobs:
       - name: Prepare deploy folder
         run: |
           mkdir -p deploy/autodoc/${{ env.VERSION }}
-
-      - name: Render html
-        uses: docker://pandoc/core:latest
-        with:
-          args: --standalone --from gfm --to html --output deploy/autodoc/${{ env.VERSION }}/index.html build/manifest.md
+          cp build/*.html deploy/autodoc/${{ env.VERSION }}/index.html
 
       - name: Render html for stable version
         if: ${{ !endsWith( env.VERSION, '-SNAPSHOT') }}


### PR DESCRIPTION
## What this PR changes/adds

use the new `doc2html` renderer to create html documentation.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
