### PR TITLE
build: get version from inputs not from the starting event

### DIFF
--- a/.github/workflows/publish-autodoc.yml
+++ b/.github/workflows/publish-autodoc.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
 
       - name: Override version if input is set
-        if: "${{ github.event.inputs.version != '' }}"
-        run: sed -i "s/version=.*/version=${{ github.event.inputs.version }}/g" gradle.properties
+        if: "${{ inputs.version != '' }}"
+        run: sed -i "s/version=.*/version=${{ inputs.version }}/g" gradle.properties
 
       - name: Generate docs
         run: ./gradlew autodoc

--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -46,8 +46,8 @@ jobs:
           path: resources/openapi/yaml
 
       - name: Override version if input is set
-        if: "${{ github.event.inputs.version != '' }}"
-        run: sed -i "s/version=.*/version=${{ github.event.inputs.version }}/g" gradle.properties
+        if: "${{ inputs.version != '' }}"
+        run: sed -i "s/version=.*/version=${{ inputs.version }}/g" gradle.properties
 
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
 


### PR DESCRIPTION
## What this PR changes/adds

According to the [documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_call), the `github.event` refers to the event that started the caller workflow, instead `inputs` refers to the actual parameters passed

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
