### PR TITLE
build(docs): get openapi version from .version file if it exists

### DIFF
--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -2,11 +2,6 @@ name: publish swagger ui
 
 on:
   workflow_call:
-    inputs:
-      version:
-        required: false
-        description: "version override"
-        type: string
 
 jobs:
   generate-openapi-spec:
@@ -45,9 +40,15 @@ jobs:
           name: openapi-spec
           path: resources/openapi/yaml
 
-      - name: Override version if input is set
-        if: "${{ inputs.version != '' }}"
-        run: sed -i "s/version=.*/version=${{ inputs.version }}/g" gradle.properties
+      - name: Get version from .version file
+        run: |
+          if [ -f resources/openapi/${{ matrix.apiGroup }}.version ]; then
+            VERSION=$(cat resources/openapi/${{ matrix.apiGroup }}.version | xargs cat | grep version | awk {'print $2'} | rev | cut -c3- | rev | cut -c2-)
+            sed -i "s/version=.*/version=$VERSION/g" gradle.properties
+            echo "${{ matrix.apiGroup }} will be published with version $VERSION"
+          else
+            echo "No version.json file found for ${{ matrix.apiGroup }} api context"
+          fi
 
       - uses: eclipse-edc/.github/.github/actions/setup-build@main
 


### PR DESCRIPTION
## What this PR changes/adds

For openapi publication: get version from the `version.json` file if it exists

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- at this point the inputs.version is not necessary anymore, because at every commit the new version of the api context will be published.

## Linked Issue(s)

Part of https://github.com/eclipse-edc/Connector/issues/4182

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
