### PR TITLE
build(docs): add reusable verify openapi workflow

### DIFF
--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -35,30 +35,26 @@ jobs:
       rootDir: resources/openapi/yaml/${{ matrix.apiGroup }}
     steps:
       - uses: actions/checkout@v4
+      - uses: eclipse-edc/.github/.github/actions/setup-build@main
       - uses: actions/download-artifact@v4
         with:
           name: openapi-spec
           path: resources/openapi/yaml
 
-      - name: Get version from .version file
+      - name: Set VERSION environment variable
         run: |
           if [ -f resources/openapi/${{ matrix.apiGroup }}.version ]; then
-            VERSION=$(cat resources/openapi/${{ matrix.apiGroup }}.version | xargs cat | grep version | awk {'print $2'} | rev | cut -c3- | rev | cut -c2-)
-            sed -i "s/version=.*/version=$VERSION/g" gradle.properties
-            echo "${{ matrix.apiGroup }} will be published with version $VERSION"
+            VERSION=$(cat ${{ env.versionFile }} | xargs cat | grep version | awk -F '"' '{print $4}')
+            echo "${{ matrix.apiGroup }} file found. Version: $VERSION"
           else
-            echo "No version.json file found for ${{ matrix.apiGroup }} api context"
+            VERSION=$(grep version= gradle.properties | cut -c 9-)
+            echo "No version.json file found for ${{ matrix.apiGroup }} api context. Project version $VERSION will be used"
           fi
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-      - uses: eclipse-edc/.github/.github/actions/setup-build@main
-
-      # merge together all api groups
       - name: Generate API Specs
         run: |
-          ./gradlew -PapiTitle="${{ matrix.apiGroup }}" -PapiDescription="REST API documentation for the ${{ matrix.apiGroup }}" :mergeApiSpec --input=${{ env.rootDir }} --output=${{ matrix.apiGroup }}.yaml
-
-      - name: extract version
-        run: echo "VERSION=$(grep version= gradle.properties | cut -c 9-)" >> $GITHUB_ENV
+          ./gradlew -Pversion=${{ env.version }} -PapiTitle="${{ matrix.apiGroup }}" -PapiDescription="REST API documentation for the ${{ matrix.apiGroup }}" :mergeApiSpec --input=${{ env.rootDir }} --output=${{ matrix.apiGroup }}.yaml
 
       - name: Generate Swagger UI current version
         uses: Legion2/swagger-ui-action@v1
@@ -77,7 +73,6 @@ jobs:
         with:
           name: ${{ matrix.apiGroup }}
           path: swagger-ui
-
 
   deploy-swagger-ui:
     needs: generate-swagger-ui

--- a/.github/workflows/verify-openapi.yml
+++ b/.github/workflows/verify-openapi.yml
@@ -1,0 +1,64 @@
+name: verify openapi versions
+
+on:
+  workflow_call:
+
+jobs:
+  prepare-api-groups:
+    runs-on: ubuntu-latest
+    outputs:
+      api_groups: ${{ steps.outputStep.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: eclipse-edc/.github/.github/actions/setup-build@main
+      - run: ./gradlew resolve
+      - uses: actions/upload-artifact@v4
+        with:
+          name: openapi-spec
+          path: resources/openapi/yaml
+      - name: get api groups to verify and create matrix for next job
+        id: outputStep
+        run: |
+          if test -d resources/openapi/yaml; then
+            API_GROUPS_ARRAY=$(ls -l resources/openapi/*.version | awk '{print $9}' | awk -F "[/\.]" '{print $3}' | sed ':a; N; $!ba; s/\n/","/g' | sed 's/.*/["&"]/')
+            echo "matrix={\"apiGroup\": ${API_GROUPS_ARRAY}}" >> $GITHUB_OUTPUT
+          fi
+
+  verify-spec:
+    if: ${{ needs.prepare-api-groups.outputs.api_groups != '' }}
+    needs: prepare-api-groups
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.prepare-api-groups.outputs.api_groups) }}
+    env:
+      versionFile: resources/openapi/${{ matrix.apiGroup }}.version
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: eclipse-edc/.github/.github/actions/setup-build@main
+      - uses: actions/download-artifact@v4
+        with:
+          name: openapi-spec
+          path: resources/openapi/yaml
+      - run: |
+          CHANGELOG=$(git diff-tree --name-only HEAD..origin/main -r)
+          if (echo $CHANGELOG | grep -q "${{ env.versionFile }}") ; then
+            echo "Version file for context ${{ matrix.apiGroup }} has been modified, no need to check differences"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          fi
+
+      - if: ( steps.verify-spec.outputs.skip != 'true' )
+        run: |
+          VERSION=$(cat ${{ env.versionFile }} | xargs cat | grep version | awk -F '"' '{print $4}')
+          ./gradlew -Pversion=$VERSION -PapiTitle="${{ matrix.apiGroup }}" -PapiDescription="REST API documentation for the ${{ matrix.apiGroup }}" :mergeApiSpec --input=resources/openapi/yaml/${{ matrix.apiGroup }} --output=${{ matrix.apiGroup }}-new.yaml
+          
+          git show origin/gh-pages:openapi/${{ matrix.apiGroup }}/${{ matrix.apiGroup }}.yaml > ${{ matrix.apiGroup }}.yaml
+          
+          diff ${{ matrix.apiGroup }}.yaml ${{ matrix.apiGroup }}-new.yaml > diff
+          
+          if [ -s diff ]; then
+              echo "${{ matrix.apiGroup }} openapi spec diverges from the published one, please update the version.json file"
+              cat diff
+              exit 1
+          fi


### PR DESCRIPTION
## What this PR changes/adds

Adds reusable workflow to verify openapi spec changes (if they changes, also the `version.json` file needs to)

## Why it does that

_Briefly state why the change was necessary._

## Further notes

- improve the `publish-openapi-ui.yml` flow as well

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
