### PR TITLE
docs: select stable version for publish/verifying openapi specs

### DIFF
--- a/.github/workflows/publish-openapi-ui.yml
+++ b/.github/workflows/publish-openapi-ui.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set VERSION environment variable
         run: |
           if [ -f ${{ env.versionFile }} ]; then
-            VERSION=$(cat ${{ env.versionFile }} | xargs cat | grep version | awk -F '"' '{print $4}')
+            VERSION=$(cat ${{ env.versionFile }} | xargs cat | jq '.[] | select(.maturity=="stable" or .maturity==null) | .version' | cut -d '"' -f 2)
             echo "${{ matrix.apiGroup }} file found. Version: $VERSION"
           else
             VERSION=$(grep version= gradle.properties | cut -c 9-)

--- a/.github/workflows/verify-openapi.yml
+++ b/.github/workflows/verify-openapi.yml
@@ -49,7 +49,7 @@ jobs:
             exit 0
           fi
 
-          VERSION=$(cat $JSON_VERSION_FILE | grep version | awk -F '"' '{print $4}')
+          VERSION=$(cat $JSON_VERSION_FILE | jq '.[] | select(.maturity=="stable" or .maturity==null) | .version' | cut -d '"' -f 2)
           ./gradlew -Pversion=$VERSION -PapiTitle="${{ matrix.apiGroup }}" -PapiDescription="REST API documentation for the ${{ matrix.apiGroup }}" :mergeApiSpec --input=resources/openapi/yaml/${{ matrix.apiGroup }} --output=${{ matrix.apiGroup }}-new.yaml
           
           git show origin/gh-pages:openapi/${{ matrix.apiGroup }}/${{ matrix.apiGroup }}.yaml > ${{ matrix.apiGroup }}.yaml


### PR DESCRIPTION
## What this PR changes/adds

Selects stable api version to use for openapi publishing/verification

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #124 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
