### PR TITLE
build: bump minor version number on release

### DIFF
--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -37,10 +37,11 @@ runs:
           INC=1
         else
           echo "$baseVersion is not a final release version (contains \"$SNAPSHOT\"), will not increase patch"
+          exit 0;
         fi
 
         # construct the new version
-        newVersion="$RELEASE_VERSION_MAJOR.$RELEASE_VERSION_MINOR.$((RELEASE_VERSION_PATCH+$INC))"-SNAPSHOT
+        newVersion="$RELEASE_VERSION_MAJOR.$((RELEASE_VERSION_MINOR+$INC)).0"-SNAPSHOT
 
         # replace every occurrence of =$baseVersion with =$newVersion
         grep -rlz "$existingVersion" . --exclude=\*.{sh,bin} | xargs sed -i "s/$existingVersion/$newVersion/g"


### PR DESCRIPTION
## What this PR changes/adds

As discussed, it makes the `bump-version` action bump the minor version number, while the patch version number is set to 0. 
This is the behavior we want to achieve on every "standard" release (where new features will be provided). For hotfix releases the process is still manual, but they should not definitely bump the snapshot version.

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
