### PR TITLE
refactor: extract a publish-maven-artifacts composite action

### DIFF
--- a/.github/actions/publish-maven-artifacts/action.yml
+++ b/.github/actions/publish-maven-artifacts/action.yml
@@ -1,0 +1,57 @@
+name: "Publish Maven Artifacts"
+description: "Build and publish maven artifacts to repository"
+
+inputs:
+  version:
+    description: the version to be attached to the artifacts, if not specified, the one configured in the project will be used
+    required: false
+  ref:
+    description: the git ref from which the artifacts will be built and published
+    required: true
+  gpg-private-key:
+    description: the gpg private key used to publish
+    required: true
+  gpg-passphrase:
+    description: the gpg passphrase used to publish
+    required: true
+  osshr-username:
+    description: the OSSHR username
+    required: true
+  osshr-password:
+    description: the OSSHR password
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+
+  - uses: actions/checkout@v4
+    with:
+      ref: ${{ inputs.ref }}
+
+  - uses: eclipse-edc/.github/.github/actions/setup-build@main
+
+  - uses: eclipse-edc/.github/.github/actions/import-gpg-key@main
+    with:
+      gpg-private-key: ${{ inputs.gpg-private-key }}
+
+  - if: inputs.version != null
+    shell: bash
+    run: |
+      sed -i 's#^version=.*#version=${{ inputs.version }}#g' $(find . -name "gradle.properties")
+
+  - name: "Publish To OSSRH/MavenCentral"
+    shell: bash
+    env:
+      OSSRH_USER: ${{ inputs.osshr-username }}
+      OSSRH_PASSWORD: ${{ inputs.osshr-password }}
+    run: |-
+      VERSION=$(grep "version" gradle.properties  | awk -F= '{print $2}') 
+      cmd=""
+      if [[ $VERSION != *-SNAPSHOT ]]
+      then
+        cmd="closeAndReleaseSonatypeStagingRepository";
+      fi
+      echo "Publishing Version $VERSION to Sonatype"
+      ./gradlew publishToSonatype ${cmd} --no-parallel -Pversion=$VERSION -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ inputs.gpg-passphrase }}"
+ 

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -30,26 +30,10 @@ jobs:
     if: |
       needs.secrets-presence.outputs.HAS_OSSRH
     steps:
-      # Set-Up
-      - uses: actions/checkout@v4
-
-      # Import GPG Key
-      - uses: eclipse-edc/.github/.github/actions/import-gpg-key@main
-        name: "Import GPG Key"
+      - uses: eclipse-edc/.github/.github/actions/publish-maven-artifacts@main
         with:
+          ref: main
           gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-
-      - uses: eclipse-edc/.github/.github/actions/setup-build@main
-      - name: "Publish snapshot version"
-        env:
-          OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
-        run: |-
-          VERSION=$(./gradlew properties -q | grep "version: " | awk '{print $2}')
-          if [[ $VERSION != *-SNAPSHOT ]]
-          then
-            echo "::warning file=gradle.properties::$VERSION is not a snapshot version - will not publish!"
-            exit 0
-          fi
-          echo "Publishing Version $VERSION to Sonatype"
-          ./gradlew publishToSonatype --no-parallel -Pversion=$VERSION -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}"
+          gpg-passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          osshr-username: ${{ secrets.ORG_OSSRH_USERNAME }}
+          osshr-password: ${{ secrets.ORG_OSSRH_PASSWORD }}

--- a/.github/workflows/technology-release.yml
+++ b/.github/workflows/technology-release.yml
@@ -23,27 +23,14 @@ jobs:
     needs: [ Determine-Version ]
     if: needs.Secrets-Presence.outputs.HAS_OSSRH
     steps:
-      - uses: actions/checkout@v4
+      - uses: eclipse-edc/.github/.github/actions/publish-maven-artifacts@main
         with:
           ref: ${{ inputs.branch }}
-
-      - uses: eclipse-edc/.github/.github/actions/setup-build@main
-
-      # Import GPG Key
-      - uses: eclipse-edc/.github/.github/actions/import-gpg-key@main
-        if: needs.Secrets-Presence.outputs.HAS_OSSRH
-        name: "Import GPG Key"
-        with:
+          version: ${{ needs.Determine-Version.outputs.VERSION }}
           gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-      - name: "Publish To OSSRH/MavenCentral"
-        if: needs.Secrets-Presence.outputs.HAS_OSSRH
-        env:
-          OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
-          OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
-          VERSION: ${{ needs.Determine-Version.outputs.VERSION }}
-        run: |-
-          echo "Publishing Version $VERSION to Sonatype"
-          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel -Pversion=$VERSION -Psigning.gnupg.executable=gpg -Psigning.gnupg.passphrase="${{ secrets.ORG_GPG_PASSPHRASE }}"
+          gpg-passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          osshr-username: ${{ secrets.ORG_OSSRH_USERNAME }}
+          osshr-password: ${{ secrets.ORG_OSSRH_PASSWORD }}
 
   Create-Tag:
     needs: [ Publish-Artefacts ]


### PR DESCRIPTION
## What this PR changes/adds

Extracts a `publish-maven-artifacts` composite action, to be reused in multiple workflows (release/snapshots/nightlies)

## Why it does that

this set of operations is highly duplicated, twice in this repository, and other occurrences are located into `Release` and `Technology-` repos as well.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
