### PR TITLE
ci: check dependencies on release preparation

### DIFF
--- a/.github/workflows/core-prepare-release.yml
+++ b/.github/workflows/core-prepare-release.yml
@@ -9,7 +9,20 @@ on:
         type: string
 
 jobs:
+  Checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout$4
+      - name: check for restricted / rejected dependencies
+        run: |
+          grep -hs -e restricted -e rejected DEPENDENCIES > unacceptable-dependencies
+          if [ -s unacceptable-dependencies ]; then
+            echo "Some dependencies are not in the expected status:"
+            cat unacceptable-dependencies
+          fi
+
   Prepare-Release:
+    needs: [ Checks ]
     runs-on: ubuntu-latest
     outputs:
       RELEASE_REF: ${{ steps.commit-changes.outputs.RELEASE_REF }}

--- a/.github/workflows/technology-prepare-release.yml
+++ b/.github/workflows/technology-prepare-release.yml
@@ -9,7 +9,20 @@ on:
         type: string
 
 jobs:
+  Checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout$4
+      - name: check for restricted / rejected dependencies
+        run: |
+          grep -hs -e restricted -e rejected DEPENDENCIES > unacceptable-dependencies
+          if [ -s unacceptable-dependencies ]; then
+            echo "Some dependencies are not in the expected status:"
+            cat unacceptable-dependencies
+          fi
+
   Prepare-Release:
+    needs: [ Checks ]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## What this PR changes/adds

Check dependencies on release preparation: no `restricted` or `rejected` will be accepted

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #142 
_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
