### PR TITLE
ci: technology release: change version before publishing artifacts

### DIFF
--- a/.github/workflows/technology-release.yml
+++ b/.github/workflows/technology-release.yml
@@ -5,24 +5,13 @@ on:
 
 jobs:
 
-  Publish-Artefacts:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: eclipse-edc/.github/.github/actions/publish-maven-artifacts@main
-        with:
-          gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-          gpg-passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}
-          osshr-username: ${{ secrets.ORG_OSSRH_USERNAME }}
-          osshr-password: ${{ secrets.ORG_OSSRH_PASSWORD }}
-
-  Create-Tag:
-    needs: [ Publish-Artefacts ]
+  Release:
     runs-on: ubuntu-latest
     outputs:
       TAG: ${{ steps.set-tag.outputs.TAG }}
     steps:
       - uses: actions/checkout@v4
+
       - id: set-version
         run: |
           VERSION=$(echo ${{ github.ref_name }} | cut -d '/' -f 2)
@@ -30,12 +19,20 @@ jobs:
       - uses: eclipse-edc/.github/.github/actions/set-project-version@main
         with:
           version: ${{ steps.set-version.outputs.VERSION }}
+
+      - uses: eclipse-edc/.github/.github/actions/publish-maven-artifacts@main
+        with:
+          gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.ORG_GPG_PASSPHRASE }}
+          osshr-username: ${{ secrets.ORG_OSSRH_USERNAME }}
+          osshr-password: ${{ secrets.ORG_OSSRH_PASSWORD }}
+
       - shell: bash
         id: set-tag
         run: |
           git config user.name "eclipse-edc-bot"
           git config user.email "edc-bot@eclipse.org"
-          
+
           TAG=v${{ steps.set-version.outputs.VERSION }}
 
           git add .
@@ -47,7 +44,7 @@ jobs:
           echo "TAG=$TAG" >> $GITHUB_OUTPUT
 
   Create-GitHub-Release:
-    needs: [ Create-Tag ]
+    needs: [ Release ]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -62,7 +59,7 @@ jobs:
           removeArtifacts: true
 
   Post-To-Discord:
-    needs: [ Publish-Artefacts, Create-Tag, Create-GitHub-Release ]
+    needs: [ Release, Create-GitHub-Release ]
     if: "always()"
     runs-on: ubuntu-latest
     steps:
@@ -71,8 +68,7 @@ jobs:
         with:
           webhook: ${{ secrets.DISCORD_GITHUB_CI_WEBHOOK }}
           # if the publishing is skipped, that means the preceding test run failed
-          status: ${{ needs.Publish-Artefacts.result }}
-          title: "Release ${{ github.repository }}"
-          description: "Build and publish ${{ needs.Create-Tag.outputs.TAG }}"
+          status: ${{ needs.Release.result }}
+          title: "Release ${{ github.repository }} ${{ needs.Release.outputs.TAG }}"
           username: GitHub Actions
 


### PR DESCRIPTION
## What this PR changes/adds

Merged the `Publish-Artefacts` and `Create-Tag` into a single `Release` job, that, in order, sets the version, publishes artifacts and creates tag

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
