### PR TITLE
chore: update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -20,6 +20,10 @@ _e.g., DPF, CI, build, transfer, etc._
 
 _Are there any requirements?_
 
+## Who will sponsor this feature?
+
+_Please @-mention the committer that will sponsor your feature_.
+
 ## Solution Proposal
 
 _If possible, provide a (brief!) solution proposal._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,12 @@ _Briefly state why the change was necessary._
 _List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
 signature changes, package declarations, bugs that were encountered and were fixed inline, etc._
 
+
+## Who will sponsor this feature?
+
+_Please @-mention the committer that will sponsor your feature_.
+
+
 ## Linked Issue(s)
 
 Closes # <-- _insert Issue number if one exists_


### PR DESCRIPTION
## What this PR changes/adds

updates the issue template adding the "Sponsor" section as per committer discussion of Jan 22nd, 2025

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
