### PR TITLE
build: fix release dependencies check

### DIFF
--- a/.github/actions/generate-dependencies-file/action.yml
+++ b/.github/actions/generate-dependencies-file/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: evaluate DEPENDENCIES
       shell: bash
       run: |
-        grep "restricted" DEPENDENCIES || true > RESTRICTED;
+        grep "restricted" DEPENDENCIES > RESTRICTED || true;
         if [ -s RESTRICTED ];
         then
           if [[ "${{ inputs.run }}" == "strict" ]];
@@ -44,7 +44,7 @@ runs:
 
         rm RESTRICTED || true
 
-        grep "rejected" DEPENDENCIES || true > REJECTED;
+        grep "rejected" DEPENDENCIES > REJECTED || true;
         if [ -s REJECTED ];
         then
           echo "error: rejected dependencies found:";


### PR DESCRIPTION
## What this PR changes/adds

Ensures that the `RESTRICTED`/`REJECTED` file is created if a restricted/rejected dependency is found.
As it is now it fails silently

## Why it does that

_Briefly state why the change was necessary._

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #169 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
