### PR TITLE
refactor: remove GradlePlugins from platform nightly/release

### DIFF
--- a/.github/workflows/platform-nightly.yml
+++ b/.github/workflows/platform-nightly.yml
@@ -32,19 +32,9 @@ jobs:
           chmod +x ./scripts/github_action.sh
           ./scripts/github_action.sh "eclipse-edc" "runtime-metamodel" "nightly.yml" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}"
 
-  GradlePlugins:
-    runs-on: ubuntu-latest
-    needs: [ Runtime-Metamodel ]
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: GradlePlugins ${{ needs.Determine-Version.outputs.VERSION }}
-        run: |
-          chmod +x ./scripts/github_action.sh
-          ./scripts/github_action.sh "eclipse-edc" "gradleplugins" "nightly.yml" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}"
-
   Connector:
     runs-on: ubuntu-latest
-    needs: [ GradlePlugins ]
+    needs: [ Runtime-Metamodel ]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Connector ${{ needs.Determine-Version.outputs.VERSION }}

--- a/.github/workflows/platform-prepare-release.yml
+++ b/.github/workflows/platform-prepare-release.yml
@@ -22,19 +22,9 @@ jobs:
           chmod +x ./scripts/github_action.sh
           ./scripts/github_action.sh "eclipse-edc" "runtime-metamodel" "prepare-release.yml" "{\"version\": \"${{ inputs.version }}\"}" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}" "${{ inputs.branch }}"
 
-  GradlePlugins:
-    runs-on: ubuntu-latest
-    needs: [ Runtime-Metamodel ]
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: GradlePlugins ${{ inputs.version }}
-        run: |
-          chmod +x ./scripts/github_action.sh
-          ./scripts/github_action.sh "eclipse-edc" "gradleplugins" "prepare-release.yml" "{\"version\": \"${{ inputs.version }}\"}" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}" "${{ inputs.branch }}"
-
   Connector:
     runs-on: ubuntu-latest
-    needs: [ GradlePlugins ]
+    needs: [ Runtime-Metamodel ]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Connector ${{ inputs.version }}

--- a/.github/workflows/platform-release.yml
+++ b/.github/workflows/platform-release.yml
@@ -23,19 +23,9 @@ jobs:
           chmod +x ./scripts/github_action.sh
           ./scripts/github_action.sh "eclipse-edc" "runtime-metamodel" "release.yml" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}" "${{ inputs.branch }}"
 
-  GradlePlugins:
-    runs-on: ubuntu-latest
-    needs: [ Runtime-Metamodel ]
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: GradlePlugins ${{ inputs.branch }}
-        run: |
-          chmod +x ./scripts/github_action.sh
-          ./scripts/github_action.sh "eclipse-edc" "gradleplugins" "release.yml" "" "${{ secrets.ORG_GITHUB_BOT_USER }}" "${{ secrets.ORG_GITHUB_BOT_TOKEN }}" "${{ inputs.branch }}"
-
   Connector:
     runs-on: ubuntu-latest
-    needs: [ GradlePlugins ]
+    needs: [ Runtime-Metamodel ]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Connector ${{ inputs.branch }}


### PR DESCRIPTION
## What this PR changes/adds

Removes `GradlePlugins` from the platform release.

## Why it does that

Not necessary anymore

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._


## Who will sponsor this feature?

_Please @-mention the committer that will sponsor your feature_.


## Linked Issue(s)

Closes #216 

_Please be sure to take a look at the [contributing guidelines](https://github.com/eclipse-edc/.github/blob/main/CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](https://github.com/eclipse-edc/.github/blob/main/contributing/pr_etiquette.md)._
